### PR TITLE
Play one audio at a time, change pause to stop

### DIFF
--- a/play_button.html
+++ b/play_button.html
@@ -1,9 +1,21 @@
 <html>
 <body>
- <audio id="$player" src="$url"></audio>
-<div>
-    <button onclick="document.getElementById('$player').play()">Play</button>
-    <button onclick="document.getElementById('$player').pause()">Pause</button>
-</div>
+  <script>
+    function stopAudio(a) {
+      a.pause();
+      a.currentTime = 0;
+    }
+    function stopAllAudios() {
+      var a = document.getElementsByTagName('audio');
+      for (i = 0; i < a.length; i++) {
+        stopAudio(a[i]);
+      }
+    }
+  </script>
+  <audio id="$player" src="$url"></audio>
+  <div>
+    <button onclick="stopAllAudios(); document.getElementById('$player').play()">Play</button>
+    <button onclick="stopAudio(document.getElementById('$player'))">Stop</button>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
This addresses some usability issues with audio playback in MUSHRA tests, where multiple audio files are present on a single test page:
- Pressing play on a second audio stops the first, rather than having multiple audios play over one another as now
- Stopping audio playback now starts from the beginning rather than pausing, which is kind of bad when there's no duration sliders for visual feedback

The approach here is kind of overkill, since it defines these JS functions on every single play button, but it's the only way I could get it to work without also requiring manual intervention in Qualtrics.

Alternative approaches:
- Only change the <button> `onclick`s, and manually add function definitions to Qualtrics page headers (tested and working)
- There is a `QuestionJS` object in the MUSHRA question payload in the template which looks like it should work as a single place to define functions per question, but I couldn't get it to work