### PR TITLE
Correct README on ordering of survey questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ Flags:
 - `-mc` = multiple choice
 - `-trs` = audio transcription
 - `-mushra` = MUSHRA
-- `mos` = MOS
+- `-mos` = MOS
 
-Questions will be added to the output test in the order you supply the flags.
+Questions will be added to the output test for each flag supplied, following the order shown above.
 
 E.g. to create a test with MUSHRA then audio transcription questions, use the command:
 


### PR DESCRIPTION
README doesn't match current behaviour of `testmaker.py`. Tests are added for each flag specified according to the order they are defined for `argparse`, not in the order flags are supplied on the command line.

Making a quick fix to the README for now to head off any questions about linking generated question IDs, which depend on this ordering, back to audio filenames programmatically. Might want to consider changing this behaviour to match the previous description, if it seems more intuitive.